### PR TITLE
[j3dcore] Work around false positive macro definition error with IntelliSense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ configure_file(
 set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreaded>$<$<CONFIG:MinSizeRel>:MultiThreaded>")
 
 if (MSVC)
-    add_compile_definitions("__BASE_FILE__=\"%(Filename)%(Extension)\"")
+    add_compile_definitions("__FILE_NAME__=\"%(Filename)%(Extension)\"")
     add_compile_options(
         /utf-8
         /Zc:__STDC__

--- a/Libs/j3dcore/j3d.h.in
+++ b/Libs/j3dcore/j3d.h.in
@@ -13,7 +13,11 @@
 #define J3D_VERSION_STRING "v@PROJECT_VERSION_PATCH@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@"
 #define J3D_VERSION_FULL   "@PROJECT_NAME@ " J3D_VERSION_STRING
 
-#define J3D_FILE __BASE_FILE__
+#if defined(_MSC_VER) && defined(__INTELLISENSE__)
+    #define J3D_FILE "dummy.cpp"
+#else
+    #define J3D_FILE __FILE_NAME__
+#endif
 
 #if defined(_M_X64) || defined(__x86_64__) || defined(_M_IA64) || defined(__ia64__) || defined(__aarch64__) || defined(__amd64)
     #define J3D_64BIT 1

--- a/Libs/j3dcore/j3d.h.in
+++ b/Libs/j3dcore/j3d.h.in
@@ -14,7 +14,7 @@
 #define J3D_VERSION_FULL   "@PROJECT_NAME@ " J3D_VERSION_STRING
 
 #if defined(_MSC_VER) && defined(__INTELLISENSE__)
-    #define J3D_FILE "dummy.cpp"
+    #define J3D_FILE "dummy.c"
 #else
     #define J3D_FILE __FILE_NAME__
 #endif


### PR DESCRIPTION
Apparently, Visual Studio's IntelliSense doesn't handle correctly the macro definitions injected from CMake `add_compile_definitions("__BASE_FILE__=\"%(Filename)%(Extension)\"")` because I kept getting reported `command-line error: invalid macro definition: __BASE_FILE__=`.

As workaround, I have redefined `J3D_FILE` to use standard __FILE__ macro (which uses full path but that's worked around already in `stdPrintf`) on MSVC. When GCC or Clang will get supported, we can use __FILE_NAME__ extension macro which does exactly what we want.