### PR TITLE
Define indent rules in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,9 @@ root = true
 
 [*.{c,c++,cc,cpp,cppm,cu,cuh,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 
+indent_style = space
+indent_size = 4
+
 # Visual C++ Code Style settings
 
 cpp_generate_documentation_comments = doxygen_slash_star


### PR DESCRIPTION
Prevents users with editors set to use tabs/different indent width to mess with project's whitespace on autoformat.