### PR TITLE
[Jones3D] Change dev mode window title

### DIFF
--- a/Jones3D/Main/JonesMain.c
+++ b/Jones3D/Main/JonesMain.c
@@ -2730,6 +2730,9 @@ int J3DAPI JonesMain_InitDevDialog(HWND hDlg, WPARAM wParam, JonesState* pConfig
 {
     J3D_UNUSED(wParam);
 
+    // Added: Adjust window title to aid new user support.
+    SetWindowText(hDlg, "Welcome to OpenJones3D");
+
     // Populate display driver combo box list
     HWND hDlgItem = GetDlgItem(hDlg, 1030); // Display driver
     for ( size_t i = 0; i < JonesMain_pStartupDisplayEnv->numInfos; ++i )


### PR DESCRIPTION
Motivation: I've dealt with a number of confused new users who can't tell if they're launching the correct engine. Hopefully, this small change will make it easier to provide efficient support to these people.