### PR TITLE
Adding support for the Clion integrated cmake generator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ Libs/std/Win95/DX9/Shaders/*.h
 # vs & vscode
 .vscode/
 .vs/
+
+# jetbrain folder
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 
 project(OpenJones3D VERSION 0.4.0)
 
@@ -57,7 +57,12 @@ configure_file(
 set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreaded>$<$<CONFIG:MinSizeRel>:MultiThreaded>")
 
 if (MSVC)
-    add_compile_definitions("__FILE_NAME__=\"%(Filename)%(Extension)\"")
+    if(DEFINED __FILE_NAME__)
+        add_compile_definitions(__FILE_NAME__=${__FILE_NAME__})
+    else()
+        add_compile_definitions("__FILE_NAME__=\"%(Filename)%(Extension)\"")
+    endif()
+
     add_compile_options(
         /utf-8
         /Zc:__STDC__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,10 @@ configure_file(
 set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreaded>$<$<CONFIG:MinSizeRel>:MultiThreaded>")
 
 if (MSVC)
-    if(DEFINED __FILE_NAME__)
-        add_compile_definitions(__FILE_NAME__=${__FILE_NAME__})
+    # Clion IDE can't read the preprocessor macro below and needs special treatment
+    if($ENV{CLION_IDE})
+        message(STATUS "Generating in Clion environment")
+        add_compile_definitions(__FILE_NAME__=__FILE__)
     else()
         add_compile_definitions("__FILE_NAME__=\"%(Filename)%(Extension)\"")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 
 project(OpenJones3D VERSION 0.4.0)
 
@@ -57,7 +57,7 @@ configure_file(
 set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreaded>$<$<CONFIG:MinSizeRel>:MultiThreaded>")
 
 if (MSVC)
-    add_compile_definitions("__FILE_NAME__=\"%(Filename)%(Extension)\"")
+    #add_compile_definitions("__FILE_NAME__=\"%(Filename)%(Extension)\"")
     add_compile_options(
         /utf-8
         /Zc:__STDC__

--- a/Libs/external/jansson/CMakeLists.txt
+++ b/Libs/external/jansson/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
 project(jansson C)
 
 # Options

--- a/Libs/j3dcore/j3d.h.in
+++ b/Libs/j3dcore/j3d.h.in
@@ -13,12 +13,10 @@
 #define J3D_VERSION_STRING "v@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@@JONES3D_BUILD_SUFFIX@"
 #define J3D_VERSION_FULL   "@PROJECT_NAME@ " J3D_VERSION_STRING
 
-#if defined(_MSC_VER) && defined(__INTELLISENSE__)
+#if defined(_MSC_VER) && defined(__INTELLISENSE__) || defined(__JETBRAINS_IDE__)
     #define J3D_FILE "dummy.c"
-#elif defined(_WIN32)
-    #define J3D_FILE (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #else
-	#define J3D_FILE (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+	#define J3D_FILE __FILE_NAME__
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__) || defined(_M_IA64) || defined(__ia64__) || defined(__aarch64__) || defined(__amd64)

--- a/Libs/j3dcore/j3d.h.in
+++ b/Libs/j3dcore/j3d.h.in
@@ -13,7 +13,7 @@
 #define J3D_VERSION_STRING "v@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@@JONES3D_BUILD_SUFFIX@"
 #define J3D_VERSION_FULL   "@PROJECT_NAME@ " J3D_VERSION_STRING
 
-#if defined(_MSC_VER) && defined(__INTELLISENSE__) || defined(__JETBRAINS_IDE__)
+#if defined(_MSC_VER) && (defined(__INTELLISENSE__) || defined(__JETBRAINS_IDE__))
     #define J3D_FILE "dummy.c"
 #else
 	#define J3D_FILE __FILE_NAME__

--- a/Libs/j3dcore/j3d.h.in
+++ b/Libs/j3dcore/j3d.h.in
@@ -15,8 +15,10 @@
 
 #if defined(_MSC_VER) && defined(__INTELLISENSE__)
     #define J3D_FILE "dummy.c"
+#elif defined(_WIN32)
+    #define J3D_FILE (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #else
-    #define J3D_FILE __FILE_NAME__
+	#define J3D_FILE (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__) || defined(_M_IA64) || defined(__ia64__) || defined(__aarch64__) || defined(__amd64)


### PR DESCRIPTION
I would like to use JetBrains Clion for working with the project. The original MSBuild macro expansion (%(Filename)%(Extension)) is only available when compiling through Visual Studio/MSBuild.
This PR adds compatibility for the integrated cmake generator in Clion. 

Also the minimum cmake version was increased to 3.5, as current cmake versions are not supporting versions < 3.5.