### PR TITLE
[Jones3D] Fix unsigned underflow in delta time calculation

### DIFF
--- a/Jones3D/Display/JonesHud.c
+++ b/Jones3D/Display/JonesHud.c
@@ -854,7 +854,7 @@ void J3DAPI JonesHud_Update(const SithWorld* pWorld)
     }
     else if ( curTime <= JonesHud_msecTime )
     {
-        JonesHud_msecDeltaTime = curTime + -1 - JonesHud_msecTime;
+        JonesHud_msecDeltaTime = (UINT32_MAX - JonesHud_msecTime + 1) + curTime;
     }
     else
     {

--- a/Libs/sith/Cog/sithCogFunctionThing.c
+++ b/Libs/sith/Cog/sithCogFunctionThing.c
@@ -5427,7 +5427,7 @@ void J3DAPI sithCogFunctionThing_BoardVehicle(SithCog* pCog)
         return;
     }
 
-    const int bBoarded = sithPlayerControls_TryBoardVehicle(pThing, /*bBoard=*/1);
+    const int bBoarded = sithPlayerControls_BoardVehicle(pThing, /*bBoard=*/1);
     sithCogExec_PushInt(pCog, bBoarded);
 }
 

--- a/Libs/sith/Cog/sithCogFunctionThing.c
+++ b/Libs/sith/Cog/sithCogFunctionThing.c
@@ -5427,7 +5427,7 @@ void J3DAPI sithCogFunctionThing_BoardVehicle(SithCog* pCog)
         return;
     }
 
-    const int bBoarded = sithPlayerControls_BoardVehicle(pThing, /*bBoard=*/1);
+    const int bBoarded = sithPlayerControls_TryBoardVehicle(pThing, /*bBoard=*/1);
     sithCogExec_PushInt(pCog, bBoarded);
 }
 


### PR DESCRIPTION
When `curTime` and `JonesHud_msecTime` are the same, which appears to be likely to happen at high FPS, the calculation would underflow and produce a huge delta time, causing jitter in item spinning.