### PR TITLE
[Jones3D] Adjust JonesHud constants to match OG layout a bit better

### DIFF
--- a/Jones3D/Display/JonesHud.c
+++ b/Jones3D/Display/JonesHud.c
@@ -98,8 +98,8 @@ static int JonesHud_bRestoreGameStatistics;
 static int JonesHud_bItemActivated;
 static int JonesHud_bExitActivated;
 
-static float JonesHud_menuItemScale          = 0.6f;
-static float JonesHud_menuItemTextPosY       = J3D_QOL_VALUE(-13.0f, 70.0f);
+static float JonesHud_menuItemScale          = 0.75f;
+static float JonesHud_menuItemTextPosY       = J3D_QOL_VALUE(-18.0f, 70.0f);
 static float JonesHud_menuItemTextSize       = J3D_QOL_VALUE(11.0f, 14.0f);
 static float JonesHud_menuItemMoveDurationMs = 250u;
 
@@ -117,7 +117,8 @@ static int JonesHud_msecMenuCloseSlideDuration      = 50;
 
 static char JonesHud_aSlectedNdsFilePath[JONESCONFIG_GAMESAVE_FILEPATHSIZE];
 
-static const float JonesHud_invMenuDefaultZ = -0.102f;
+// Original constant was -0.102f but this centers the item posiition with the health indicator better
+static const float JonesHud_invMenuDefaultZ = -0.104f;
 static float JonesHud_invMenuMinZ           = 0.0f;
 static float JonesHud_invMenuMaxZ           = 0.0f;
 
@@ -1453,11 +1454,8 @@ void J3DAPI JonesHud_UpdateHUDLayout(uint32_t width, uint32_t height)
     JonesHud_flt_554FE4 = 16.0f * JonesHud_heightAspectRatioScale;
     JonesHud_flt_554FE0 = 16.0f * JonesHud_widthAspectRatioScale;
 
-    // Fixed: Adjusted inventory menu position for wide screen resolutions. OG: invMenuBottomOffset was set to invMenuDefaultOffset
-    float adjustedAspect = (RD_REF_APECTRATIO / (width / height));
-    float adjustedZ      = JonesHud_invMenuDefaultZ * adjustedAspect;
-    float offset         = -0.09f * (1 - adjustedAspect); // Add a small offset to move it slightly up
-    JonesHud_invMenuMinZ = adjustedZ + offset;
+    // No need to adjust inventory height based on aspect ratio anymore
+    JonesHud_invMenuMinZ = JonesHud_invMenuDefaultZ;
 }
 
 void JonesHud_MenuOpen(void)


### PR DESCRIPTION
In 0.4 rc1, the inventory items are scaled a bit too small compared to the health indicator. This PR changes the default scale `JonesHud_menuItemScale` to produce item size very similar to OG. I adjusted `JonesHud_menuItemTextPosY` to account for the larger items to keep the text out of the 3D model. I removed the seemingly obsolete chunk of code that tried to adjust inventory height based on aspect ratio so now a predictable value is used for everybody. I changed `JonesHud_invMenuDefaultZ` to 0.104f to stop items from sticking out above the health indicator.

# Screenshots:

### Vanilla:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/6ed8e906-ca32-4bbe-afb3-c02209c7672c" />

### 0.4 rc1
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/84bd2d93-166c-4695-bc9d-c8a14c877f4c" />

### This PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/9b798bb6-76ff-4658-b451-5327812e7c55" />
